### PR TITLE
[Editorial] days → days’ (Ch. 55)

### DIFF
--- a/src/epub/text/chapter-55.xhtml
+++ b/src/epub/text/chapter-55.xhtml
@@ -8,7 +8,7 @@
 	<body epub:type="bodymatter z3998:fiction">
 		<section id="chapter-55" epub:type="chapter">
 			<h2 epub:type="ordinal z3998:roman">LV</h2>
-			<p>A few days after this visit, <abbr epub:type="z3998:name-title">Mr.</abbr> Bingley called again, and alone. His friend had left him that morning for London, but was to return home in ten days time. He sat with them above an hour, and was in remarkably good spirits. <abbr epub:type="z3998:name-title">Mrs.</abbr> Bennet invited him to dine with them; but, with many expressions of concern, he confessed himself engaged elsewhere.</p>
+			<p>A few days after this visit, <abbr epub:type="z3998:name-title">Mr.</abbr> Bingley called again, and alone. His friend had left him that morning for London, but was to return home in ten days’ time. He sat with them above an hour, and was in remarkably good spirits. <abbr epub:type="z3998:name-title">Mrs.</abbr> Bennet invited him to dine with them; but, with many expressions of concern, he confessed himself engaged elsewhere.</p>
 			<p>“Next time you call,” said she, “I hope we shall be more lucky.”</p>
 			<p>He should be particularly happy at any time, <abbr>etc.</abbr> <abbr>etc.</abbr>; and if she would give him leave, would take an early opportunity of waiting on them.</p>
 			<p>“Can you come tomorrow?”</p>


### PR DESCRIPTION
Missing apostrophe added.

in ten days time → in ten days’ time

Page scans at HaitiTrust (https://catalog.hathitrust.org/Record/000429470) has the apostrophe.